### PR TITLE
Common properties in sealed classes

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedProduct.kt
@@ -133,6 +133,7 @@ private fun FetchedProduct.ProductOption.CheckboxOption.toUpdated() = UpdatedPro
 	name = name,
 	nameTranslated = nameTranslated,
 	choices = choices.map { it.toUpdated() },
+	defaultChoice = defaultChoice,
 	required = required
 )
 

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/request/UpdatedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/request/UpdatedProduct.kt
@@ -101,6 +101,7 @@ data class UpdatedProduct(
 	) {
 		abstract val name: String
 		abstract val nameTranslated: LocalizedValueMap?
+		abstract val required: Boolean
 
 		interface ChoiceBased {
 			val choices: List<ProductOptionChoice>
@@ -112,7 +113,7 @@ data class UpdatedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int = 0,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.SELECT), ChoiceBased
 
 		data class SizeOption(
@@ -120,7 +121,7 @@ data class UpdatedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int = 0,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.SIZE), ChoiceBased
 
 		data class RadioOption(
@@ -128,7 +129,7 @@ data class UpdatedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int = 0,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.RADIO), ChoiceBased
 
 		data class CheckboxOption(
@@ -136,31 +137,31 @@ data class UpdatedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.CHECKBOX), ChoiceBased
 
 		data class TextFieldOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.TEXTFIELD)
 
 		data class TextAreaOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.TEXTAREA)
 
 		data class DateOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.DATE)
 
 		data class FilesOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.FILES)
 
 		companion object {

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/request/UpdatedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/request/UpdatedProduct.kt
@@ -102,36 +102,42 @@ data class UpdatedProduct(
 		abstract val name: String
 		abstract val nameTranslated: LocalizedValueMap?
 
+		interface ChoiceBased {
+			val choices: List<ProductOptionChoice>
+			val defaultChoice: Int?
+		}
+
 		data class SelectOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
-			val defaultChoice: Int = 0,
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int = 0,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.SELECT)
+		) : ProductOption(ProductOptionType.SELECT), ChoiceBased
 
 		data class SizeOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
-			val defaultChoice: Int = 0,
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int = 0,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.SIZE)
+		) : ProductOption(ProductOptionType.SIZE), ChoiceBased
 
 		data class RadioOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
-			val defaultChoice: Int = 0,
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int = 0,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.RADIO)
+		) : ProductOption(ProductOptionType.RADIO), ChoiceBased
 
 		data class CheckboxOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int? = null,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.CHECKBOX)
+		) : ProductOption(ProductOptionType.CHECKBOX), ChoiceBased
 
 		data class TextFieldOption(
 			override val name: String = "",

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
@@ -159,36 +159,42 @@ data class FetchedProduct(
 		abstract val name: String
 		abstract val nameTranslated: LocalizedValueMap?
 
+		interface ChoiceBased {
+			val choices: List<ProductOptionChoice>
+			val defaultChoice: Int?
+		}
+
 		data class SelectOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
-			val defaultChoice: Int = 0,
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int = 0,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.SELECT)
+		) : ProductOption(ProductOptionType.SELECT), ChoiceBased
 
 		data class SizeOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
-			val defaultChoice: Int = 0,
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int = 0,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.SIZE)
+		) : ProductOption(ProductOptionType.SIZE), ChoiceBased
 
 		data class RadioOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
-			val defaultChoice: Int = 0,
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int = 0,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.RADIO)
+		) : ProductOption(ProductOptionType.RADIO), ChoiceBased
 
 		data class CheckboxOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val choices: List<ProductOptionChoice> = listOf(),
+			override val choices: List<ProductOptionChoice> = listOf(),
+			override val defaultChoice: Int? = null,
 			val required: Boolean = false
-		) : ProductOption(ProductOptionType.CHECKBOX)
+		) : ProductOption(ProductOptionType.CHECKBOX), ChoiceBased
 
 		data class TextFieldOption(
 			override val name: String = "",

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
@@ -158,6 +158,7 @@ data class FetchedProduct(
 
 		abstract val name: String
 		abstract val nameTranslated: LocalizedValueMap?
+		abstract val required: Boolean
 
 		interface ChoiceBased {
 			val choices: List<ProductOptionChoice>
@@ -169,7 +170,7 @@ data class FetchedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int = 0,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.SELECT), ChoiceBased
 
 		data class SizeOption(
@@ -177,7 +178,7 @@ data class FetchedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int = 0,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.SIZE), ChoiceBased
 
 		data class RadioOption(
@@ -185,7 +186,7 @@ data class FetchedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int = 0,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.RADIO), ChoiceBased
 
 		data class CheckboxOption(
@@ -193,31 +194,31 @@ data class FetchedProduct(
 			override val nameTranslated: LocalizedValueMap? = null,
 			override val choices: List<ProductOptionChoice> = listOf(),
 			override val defaultChoice: Int? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.CHECKBOX), ChoiceBased
 
 		data class TextFieldOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.TEXTFIELD)
 
 		data class TextAreaOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.TEXTAREA)
 
 		data class DateOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.DATE)
 
 		data class FilesOption(
 			override val name: String = "",
 			override val nameTranslated: LocalizedValueMap? = null,
-			val required: Boolean = false
+			override val required: Boolean = false
 		) : ProductOption(ProductOptionType.FILES)
 	}
 

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/NullablePropertyRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/NullablePropertyRules.kt
@@ -41,6 +41,7 @@ val otherNullablePropertyRules: List<NullablePropertyRule<*, *>> = listOf(
 	AllowNullable(FetchedProduct.ShippingPreparationTime::shippingPreparationTimeForInStockItemDays),
 	AllowNullable(FetchedProduct.ShippingPreparationTime::shippingPreparationTimeForOutOfStockItemDays),
 	AllowNullable(FetchedProduct.ShippingPreparationTime::localDeliveryPreparationTimeForInStockItemInMinutes),
+	AllowNullable(FetchedProduct.ProductOption.ChoiceBased::defaultChoice),
 
 	IgnoreNullable(ConvertCartToOrderResult::id),
 	IgnoreNullable(ConvertCartToOrderResult::orderNumber),

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/NullablePropertyRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/NullablePropertyRules.kt
@@ -42,6 +42,7 @@ val otherNullablePropertyRules: List<NullablePropertyRule<*, *>> = listOf(
 	AllowNullable(FetchedProduct.ShippingPreparationTime::shippingPreparationTimeForOutOfStockItemDays),
 	AllowNullable(FetchedProduct.ShippingPreparationTime::localDeliveryPreparationTimeForInStockItemInMinutes),
 	AllowNullable(FetchedProduct.ProductOption.ChoiceBased::defaultChoice),
+	AllowNullable(FetchedProduct.ProductOption.CheckboxOption::defaultChoice),
 
 	IgnoreNullable(ConvertCartToOrderResult::id),
 	IgnoreNullable(ConvertCartToOrderResult::orderNumber),


### PR DESCRIPTION
Make properties 'required', 'choices' and 'defaultChoice' in FetchedProduct.ProductOption and UpdatedProduct.ProductOption easier to access.

Note: defaultChoice was absent in CheckboxOption class, but to avoid making hierarchy more complex I decided to add it to the CheckboxOption with value null by default. It should not affect requests because server discards it as irrelevant