### PR TITLE
Fix equality check to comply with changes in server's response

### DIFF
--- a/src/test/kotlin/com/ecwid/apiclient/v3/entity/CategoriesTest.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/entity/CategoriesTest.kt
@@ -537,7 +537,17 @@ private fun generateTestCategory(
 		),
 		enabled = enabled,
 		productIds = productIds,
-		isSampleCategory = false
+		isSampleCategory = false,
+		seoTitle = "",
+		seoTitleTranslated = LocalizedValueMap(
+			"ru" to "",
+			"en" to ""
+		),
+		seoDescription = "",
+		seoDescriptionTranslated = LocalizedValueMap(
+			"ru" to "",
+			"en" to ""
+		)
 	)
 }
 


### PR DESCRIPTION
If there are translations of other fields, the server now returns a map with empty values instead of null in fields seoTitleTranslated and seoTitleTranslated