### PR TITLE
Fix deserialization of enums

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ComparePeriod.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ComparePeriod.kt
@@ -1,20 +1,9 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
-import com.google.gson.annotations.SerializedName
-
-enum class ComparePeriod(val alias: String) {
-	@SerializedName("previousPeriod")
-	PREVIOUS_PERIOD("previousPeriod"),
-
-	@SerializedName("similarPeriodInPreviousWeek")
-	SIMILAR_PERIOD_IN_PREVIOUS_WEEK("similarPeriodInPreviousWeek"),
-
-	@SerializedName("similarPeriodInPreviousMonth")
-	SIMILAR_PERIOD_IN_PREVIOUS_MONTH("similarPeriodInPreviousMonth"),
-
-	@SerializedName("similarPeriodInPreviousYear")
-	SIMILAR_PERIOD_IN_PREVIOUS_YEAR("similarPeriodInPreviousYear"),
-
-	@SerializedName("noComparePeriod")
-	NO_COMPARE_PERIOD("noComparePeriod");
+enum class ComparePeriod {
+	previousPeriod,
+	similarPeriodInPreviousWeek,
+	similarPeriodInPreviousMonth,
+	similarPeriodInPreviousYear,
+	noComparePeriod;
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ComparePeriod.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ComparePeriod.kt
@@ -1,9 +1,20 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
+import com.google.gson.annotations.SerializedName
+
 enum class ComparePeriod(val alias: String) {
+	@SerializedName("previousPeriod")
 	PREVIOUS_PERIOD("previousPeriod"),
+
+	@SerializedName("similarPeriodInPreviousWeek")
 	SIMILAR_PERIOD_IN_PREVIOUS_WEEK("similarPeriodInPreviousWeek"),
+
+	@SerializedName("similarPeriodInPreviousMonth")
 	SIMILAR_PERIOD_IN_PREVIOUS_MONTH("similarPeriodInPreviousMonth"),
+
+	@SerializedName("similarPeriodInPreviousYear")
 	SIMILAR_PERIOD_IN_PREVIOUS_YEAR("similarPeriodInPreviousYear"),
+
+	@SerializedName("noComparePeriod")
 	NO_COMPARE_PERIOD("noComparePeriod");
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/FirstDayOfWeek.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/FirstDayOfWeek.kt
@@ -1,11 +1,6 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
-import com.google.gson.annotations.SerializedName
-
-enum class FirstDayOfWeek(val alias: String) {
-	@SerializedName("monday")
-	MONDAY("monday"),
-
-	@SerializedName("sunday")
-	SUNDAY("sunday");
+enum class FirstDayOfWeek {
+	monday,
+	sunday;
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/FirstDayOfWeek.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/FirstDayOfWeek.kt
@@ -1,6 +1,11 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
+import com.google.gson.annotations.SerializedName
+
 enum class FirstDayOfWeek(val alias: String) {
+	@SerializedName("monday")
 	MONDAY("monday"),
+
+	@SerializedName("sunday")
 	SUNDAY("sunday");
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ReportType.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ReportType.kt
@@ -1,11 +1,6 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
-import com.google.gson.annotations.SerializedName
-
-enum class ReportType(val alias: String) {
-	@SerializedName("allTraffic")
-	ALL_TRAFFIC("allTraffic"),
-
-	@SerializedName("newVsReturningVisitors")
-	NEW_VS_RETURNING_VISITORS("newVsReturningVisitors"),
+enum class ReportType {
+	allTraffic,
+	newVsReturningVisitors,
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ReportType.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/ReportType.kt
@@ -1,6 +1,11 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
+import com.google.gson.annotations.SerializedName
+
 enum class ReportType(val alias: String) {
+	@SerializedName("allTraffic")
 	ALL_TRAFFIC("allTraffic"),
+
+	@SerializedName("newVsReturningVisitors")
 	NEW_VS_RETURNING_VISITORS("newVsReturningVisitors"),
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/TimeScaleValue.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/TimeScaleValue.kt
@@ -1,9 +1,20 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
+import com.google.gson.annotations.SerializedName
+
 enum class TimeScaleValue(val alias: String) {
+	@SerializedName("hour")
 	HOUR("hour"),
+
+	@SerializedName("day")
 	DAY("day"),
+
+	@SerializedName("week")
 	WEEK("week"),
+
+	@SerializedName("month")
 	MONTH("month"),
+
+	@SerializedName("year")
 	YEAR("year");
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/TimeScaleValue.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/enums/TimeScaleValue.kt
@@ -1,20 +1,9 @@
 package com.ecwid.apiclient.v3.dto.report.enums
 
-import com.google.gson.annotations.SerializedName
-
-enum class TimeScaleValue(val alias: String) {
-	@SerializedName("hour")
-	HOUR("hour"),
-
-	@SerializedName("day")
-	DAY("day"),
-
-	@SerializedName("week")
-	WEEK("week"),
-
-	@SerializedName("month")
-	MONTH("month"),
-
-	@SerializedName("year")
-	YEAR("year");
+enum class TimeScaleValue {
+	hour,
+	day,
+	week,
+	month,
+	year;
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/request/ReportRequest.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/request/ReportRequest.kt
@@ -8,7 +8,7 @@ import com.ecwid.apiclient.v3.dto.report.enums.TimeScaleValue
 import com.ecwid.apiclient.v3.impl.RequestInfo
 
 data class ReportRequest(
-	val reportType: ReportType = ReportType.ALL_TRAFFIC,
+	val reportType: ReportType = ReportType.allTraffic,
 	val startedFrom: Long? = null,
 	val endedAt: Long? = null,
 	val timeScaleValue: TimeScaleValue? = null,
@@ -19,7 +19,7 @@ data class ReportRequest(
 	override fun toRequestInfo() = RequestInfo.createGetRequest(
 		pathSegments = listOf(
 			"reports",
-			reportType.alias,
+			reportType.toString(),
 		),
 		params = toParams()
 	)
@@ -28,9 +28,9 @@ data class ReportRequest(
 		return mutableMapOf<String, String>().apply {
 			startedFrom?.let { put("startedFrom", it.toString()) }
 			endedAt?.let { put("endedAt", it.toString()) }
-			timeScaleValue?.let { put("timeScaleValue", it.alias) }
-			comparePeriod?.let { put("comparePeriod", it.alias) }
-			firstDayOfWeek?.let { put("firstDayOfWeek", it.alias) }
+			timeScaleValue?.let { put("timeScaleValue", it.toString()) }
+			comparePeriod?.let { put("comparePeriod", it.toString()) }
+			firstDayOfWeek?.let { put("firstDayOfWeek", it.toString()) }
 		}.toMap()
 	}
 

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/result/FetchedReportResponse.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/report/result/FetchedReportResponse.kt
@@ -6,7 +6,7 @@ import com.ecwid.apiclient.v3.dto.report.enums.ReportType
 import com.ecwid.apiclient.v3.dto.report.enums.TimeScaleValue
 
 data class FetchedReportResponse(
-	val reportType: ReportType = ReportType.ALL_TRAFFIC,
+	val reportType: ReportType = ReportType.allTraffic,
 	val startedFrom: Long = 0,
 	val endedAt: Long = 0,
 	val timeScaleValue: TimeScaleValue? = null,


### PR DESCRIPTION
Енамы в ответах для Reports API неправильно парсятся, gson не может найти подходящего значения и всегда ставит null.