### PR TITLE
Alt-text support for all category images

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
@@ -17,6 +17,12 @@ fun FetchedCategory.toUpdated(): UpdatedCategory {
 		seoTitle = seoTitle,
 		seoTitleTranslated = seoTitleTranslated,
 		seoDescription = seoDescription,
-		seoDescriptionTranslated = seoDescriptionTranslated
+		seoDescriptionTranslated = seoDescriptionTranslated,
+		imageAlt = imageAlt?.toUpdated()
 	)
 }
+
+fun FetchedCategory.Alt.toUpdated() = UpdatedCategory.Alt(
+	main = main,
+	translated = translated
+)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
@@ -18,8 +18,14 @@ data class UpdatedCategory(
 	val seoTitle: String? = null,
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
-	val seoDescriptionTranslated: LocalizedValueMap? = null
+	val seoDescriptionTranslated: LocalizedValueMap? = null,
+	val imageAlt: Alt? = null
 ) : ApiUpdatedDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(FetchedCategory::class)
+
+	data class Alt(
+		val main: String? = null,
+		val translated: LocalizedValueMap? = null
+	)
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
@@ -32,8 +32,14 @@ data class FetchedCategory(
 	val seoTitle: String? = null,
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
-	val seoDescriptionTranslated: LocalizedValueMap? = null
+	val seoDescriptionTranslated: LocalizedValueMap? = null,
+	val imageAlt: Alt? = null
 ) : ApiFetchedDTO, ApiResultDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(UpdatedCategory::class)
+
+	data class Alt(
+		val main: String? = null,
+		val translated: LocalizedValueMap? = null
+	)
 }

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
@@ -25,5 +25,8 @@ val fetchedCategoryNullablePropertyRules: List<NullablePropertyRule<*, *>> = lis
 	AllowNullable(FetchedCategory::seoTitle),
 	AllowNullable(FetchedCategory::seoTitleTranslated),
 	AllowNullable(FetchedCategory::seoDescription),
-	AllowNullable(FetchedCategory::seoDescriptionTranslated)
+	AllowNullable(FetchedCategory::seoDescriptionTranslated),
+	AllowNullable(FetchedCategory::imageAlt),
+	AllowNullable(FetchedCategory.Alt::main),
+	AllowNullable(FetchedCategory.Alt::translated)
 )


### PR DESCRIPTION
In order to add the new property imageAlt for category in ISv2, we need to add it in the FetchedCategory class and related functions.