### PR TITLE
Ecwid 116234 api client change

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
@@ -18,7 +18,7 @@ fun FetchedCategory.toUpdated(): UpdatedCategory {
 		seoTitleTranslated = seoTitleTranslated,
 		seoDescription = seoDescription,
 		seoDescriptionTranslated = seoDescriptionTranslated,
-		imageAlt = imageAlt?.toUpdated()
+		alt = alt?.toUpdated()
 	)
 }
 

--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
@@ -17,6 +17,12 @@ fun FetchedCategory.toUpdated(): UpdatedCategory {
 		seoTitle = seoTitle,
 		seoTitleTranslated = seoTitleTranslated,
 		seoDescription = seoDescription,
-		seoDescriptionTranslated = seoDescriptionTranslated
+		seoDescriptionTranslated = seoDescriptionTranslated,
+		imageAlt = imageAlt?.toUpdated()
 	)
 }
+
+fun FetchedCategory.Alt.toUpdated() = UpdatedCategory.Alt(
+	main = main,
+	translated = translated
+)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
@@ -18,11 +18,6 @@ fun FetchedCategory.toUpdated(): UpdatedCategory {
 		seoTitleTranslated = seoTitleTranslated,
 		seoDescription = seoDescription,
 		seoDescriptionTranslated = seoDescriptionTranslated,
-		alt = alt?.toUpdated()
+		alt = alt?.toUpdated(),
 	)
 }
-
-fun FetchedCategory.Alt.toUpdated() = UpdatedCategory.Alt(
-	main = main,
-	translated = translated
-)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedProduct.kt
@@ -224,11 +224,6 @@ fun FetchedProduct.ProductImage.toUpdated() = UpdatedProduct.ProductImage(
 	alt = alt?.toUpdated()
 )
 
-fun FetchedProduct.ProductImage.Alt.toUpdated() = UpdatedProduct.ProductImage.Alt(
-	main = main,
-	translated = translated
-)
-
 fun FetchedProduct.TaxInfo.toUpdated() = UpdatedProduct.TaxInfo(
 	taxable = taxable,
 	enabledManualTaxes = enabledManualTaxes,

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
@@ -19,7 +19,7 @@ data class UpdatedCategory(
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
 	val seoDescriptionTranslated: LocalizedValueMap? = null,
-	val imageAlt: Alt? = null
+	val alt: Alt? = null
 ) : ApiUpdatedDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(FetchedCategory::class)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
@@ -4,6 +4,7 @@ import com.ecwid.apiclient.v3.dto.category.result.FetchedCategory
 import com.ecwid.apiclient.v3.dto.common.ApiUpdatedDTO
 import com.ecwid.apiclient.v3.dto.common.ApiUpdatedDTO.ModifyKind
 import com.ecwid.apiclient.v3.dto.common.LocalizedValueMap
+import com.ecwid.apiclient.v3.dto.common.UpdatedAlt
 
 data class UpdatedCategory(
 	val parentId: Int? = null,
@@ -19,13 +20,9 @@ data class UpdatedCategory(
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
 	val seoDescriptionTranslated: LocalizedValueMap? = null,
-	val alt: Alt? = null
+	val alt: UpdatedAlt? = null
 ) : ApiUpdatedDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(FetchedCategory::class)
 
-	data class Alt(
-		val main: String? = null,
-		val translated: LocalizedValueMap? = null
-	)
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
@@ -18,8 +18,14 @@ data class UpdatedCategory(
 	val seoTitle: String? = null,
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
-	val seoDescriptionTranslated: LocalizedValueMap? = null
+	val seoDescriptionTranslated: LocalizedValueMap? = null,
+	val imageAlt: Alt? = null
 ) : ApiUpdatedDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(FetchedCategory::class)
+
+	data class Alt(
+		val main: String? = null,
+		val translated: LocalizedValueMap? = null
+	)
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
@@ -4,6 +4,7 @@ import com.ecwid.apiclient.v3.dto.category.request.UpdatedCategory
 import com.ecwid.apiclient.v3.dto.common.ApiFetchedDTO
 import com.ecwid.apiclient.v3.dto.common.ApiFetchedDTO.ModifyKind
 import com.ecwid.apiclient.v3.dto.common.ApiResultDTO
+import com.ecwid.apiclient.v3.dto.common.FetchedAlt
 import com.ecwid.apiclient.v3.dto.common.LocalizedValueMap
 import com.ecwid.apiclient.v3.dto.common.PictureInfo
 
@@ -33,13 +34,9 @@ data class FetchedCategory(
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
 	val seoDescriptionTranslated: LocalizedValueMap? = null,
-	val alt: Alt? = null
+	val alt: FetchedAlt? = null
 ) : ApiFetchedDTO, ApiResultDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(UpdatedCategory::class)
 
-	data class Alt(
-		val main: String? = null,
-		val translated: LocalizedValueMap? = null
-	)
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
@@ -32,8 +32,14 @@ data class FetchedCategory(
 	val seoTitle: String? = null,
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
-	val seoDescriptionTranslated: LocalizedValueMap? = null
+	val seoDescriptionTranslated: LocalizedValueMap? = null,
+	val imageAlt: Alt? = null
 ) : ApiFetchedDTO, ApiResultDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(UpdatedCategory::class)
+
+	data class Alt(
+		val main: String? = null,
+		val translated: LocalizedValueMap? = null
+	)
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
@@ -33,7 +33,7 @@ data class FetchedCategory(
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
 	val seoDescriptionTranslated: LocalizedValueMap? = null,
-	val imageAlt: Alt? = null
+	val alt: Alt? = null
 ) : ApiFetchedDTO, ApiResultDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(UpdatedCategory::class)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/Alt.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/Alt.kt
@@ -4,7 +4,7 @@ data class FetchedAlt(
 	val main: String? = null,
 	val translated: LocalizedValueMap? = null,
 ) {
-	fun toUpdated(): UpdatedAlt{
+	fun toUpdated(): UpdatedAlt {
 		return UpdatedAlt(
 			main = main,
 			translated = translated

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/Alt.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/Alt.kt
@@ -1,0 +1,18 @@
+package com.ecwid.apiclient.v3.dto.common
+
+data class FetchedAlt(
+	val main: String? = null,
+	val translated: LocalizedValueMap? = null,
+) {
+	fun toUpdated(): UpdatedAlt{
+		return UpdatedAlt(
+			main = main,
+			translated = translated
+		)
+	}
+}
+
+data class UpdatedAlt(
+	val main: String? = null,
+	val translated: LocalizedValueMap? = null,
+)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/request/UpdatedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/request/UpdatedProduct.kt
@@ -373,13 +373,8 @@ data class UpdatedProduct(
 	data class ProductImage(
 		val id: String = "0",
 		val orderBy: Int = 0,
-		val alt: Alt? = null
-	) {
-		data class Alt(
-			val main: String? = null,
-			val translated: LocalizedValueMap? = null
-		)
-	}
+		val alt: UpdatedAlt? = null
+	)
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(FetchedProduct::class)
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
@@ -345,13 +345,8 @@ data class FetchedProduct(
 		val image800pxUrl: String? = null,
 		val image1500pxUrl: String? = null,
 		val imageOriginalUrl: String? = null,
-		val alt: Alt? = null
-	) {
-		data class Alt(
-			val main: String? = null,
-			val translated: LocalizedValueMap? = null
-		)
-	}
+		val alt: FetchedAlt? = null
+	)
 
 	data class ProductVideo(
 		val id: String = "0",

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/subscriptions/request/SubscriptionsSearchRequest.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/subscriptions/request/SubscriptionsSearchRequest.kt
@@ -65,8 +65,8 @@ data class SubscriptionsSearchRequest(
 			orderTotal?.let { put("orderTotal", it.toString()) }
 			orderCreatedFrom?.let { put("orderCreatedFrom", TimeUnit.MILLISECONDS.toSeconds(it.time).toString()) }
 			orderCreatedTo?.let { put("orderCreatedTo", TimeUnit.MILLISECONDS.toSeconds(it.time).toString()) }
-			offset.let { put("offset", it.toString()) }
-			limit.let { put("limit", it.toString()) }
+			offset?.let { put("offset", it.toString()) }
+			limit?.let { put("limit", it.toString()) }
 			put("sortBy", sortBy.name)
 			lang?.let { put("lang", it) }
 		}.toMap()

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/subscriptions/request/SubscriptionsSearchRequest.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/subscriptions/request/SubscriptionsSearchRequest.kt
@@ -65,8 +65,8 @@ data class SubscriptionsSearchRequest(
 			orderTotal?.let { put("orderTotal", it.toString()) }
 			orderCreatedFrom?.let { put("orderCreatedFrom", TimeUnit.MILLISECONDS.toSeconds(it.time).toString()) }
 			orderCreatedTo?.let { put("orderCreatedTo", TimeUnit.MILLISECONDS.toSeconds(it.time).toString()) }
-			offset?.let { put("offset", it.toString()) }
-			limit?.let { put("limit", it.toString()) }
+			offset.let { put("offset", it.toString()) }
+			limit.let { put("limit", it.toString()) }
 			put("sortBy", sortBy.name)
 			lang?.let { put("lang", it) }
 		}.toMap()

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
@@ -27,6 +27,4 @@ val fetchedCategoryNullablePropertyRules: List<NullablePropertyRule<*, *>> = lis
 	AllowNullable(FetchedCategory::seoDescription),
 	AllowNullable(FetchedCategory::seoDescriptionTranslated),
 	AllowNullable(FetchedCategory::alt),
-	AllowNullable(FetchedCategory.Alt::main),
-	AllowNullable(FetchedCategory.Alt::translated)
 )

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
@@ -26,7 +26,7 @@ val fetchedCategoryNullablePropertyRules: List<NullablePropertyRule<*, *>> = lis
 	AllowNullable(FetchedCategory::seoTitleTranslated),
 	AllowNullable(FetchedCategory::seoDescription),
 	AllowNullable(FetchedCategory::seoDescriptionTranslated),
-	AllowNullable(FetchedCategory::imageAlt),
+	AllowNullable(FetchedCategory::alt),
 	AllowNullable(FetchedCategory.Alt::main),
 	AllowNullable(FetchedCategory.Alt::translated)
 )

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
@@ -25,5 +25,8 @@ val fetchedCategoryNullablePropertyRules: List<NullablePropertyRule<*, *>> = lis
 	AllowNullable(FetchedCategory::seoTitle),
 	AllowNullable(FetchedCategory::seoTitleTranslated),
 	AllowNullable(FetchedCategory::seoDescription),
-	AllowNullable(FetchedCategory::seoDescriptionTranslated)
+	AllowNullable(FetchedCategory::seoDescriptionTranslated),
+	AllowNullable(FetchedCategory::imageAlt),
+	AllowNullable(FetchedCategory.Alt::main),
+	AllowNullable(FetchedCategory.Alt::translated)
 )

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
@@ -1,6 +1,7 @@
 package com.ecwid.apiclient.v3.rule.nullablepropertyrules
 
 import com.ecwid.apiclient.v3.dto.category.result.FetchedCategory
+import com.ecwid.apiclient.v3.dto.common.FetchedAlt
 import com.ecwid.apiclient.v3.rule.NullablePropertyRule
 import com.ecwid.apiclient.v3.rule.NullablePropertyRule.AllowNullable
 import com.ecwid.apiclient.v3.rule.NullablePropertyRule.IgnoreNullable
@@ -27,4 +28,6 @@ val fetchedCategoryNullablePropertyRules: List<NullablePropertyRule<*, *>> = lis
 	AllowNullable(FetchedCategory::seoDescription),
 	AllowNullable(FetchedCategory::seoDescriptionTranslated),
 	AllowNullable(FetchedCategory::alt),
+	AllowNullable(FetchedAlt::main),
+	AllowNullable(FetchedAlt::translated),
 )

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedProductRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedProductRules.kt
@@ -99,8 +99,6 @@ val fetchedProductNullablePropertyRules: List<NullablePropertyRule<*, *>> = list
 	IgnoreNullable(FetchedProduct.ProductImage::image800pxUrl),
 	IgnoreNullable(FetchedProduct.ProductImage::imageOriginalUrl),
 	AllowNullable(FetchedProduct.ProductImage::alt),
-	AllowNullable(FetchedProduct.ProductImage.Alt::main),
-	AllowNullable(FetchedProduct.ProductImage.Alt::translated),
 	AllowNullable(FetchedProduct.ProductVideo::videoCoverId),
 	AllowNullable(FetchedProduct.ProductVideo::image160pxUrl),
 	AllowNullable(FetchedProduct.ProductVideo::image400pxUrl),

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedProductRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedProductRules.kt
@@ -1,5 +1,6 @@
 package com.ecwid.apiclient.v3.rule.nullablepropertyrules
 
+import com.ecwid.apiclient.v3.dto.common.FetchedAlt
 import com.ecwid.apiclient.v3.dto.product.result.FetchedProduct
 import com.ecwid.apiclient.v3.rule.NullablePropertyRule
 import com.ecwid.apiclient.v3.rule.NullablePropertyRule.AllowNullable
@@ -99,6 +100,8 @@ val fetchedProductNullablePropertyRules: List<NullablePropertyRule<*, *>> = list
 	IgnoreNullable(FetchedProduct.ProductImage::image800pxUrl),
 	IgnoreNullable(FetchedProduct.ProductImage::imageOriginalUrl),
 	AllowNullable(FetchedProduct.ProductImage::alt),
+	AllowNullable(FetchedAlt::main),
+	AllowNullable(FetchedAlt::translated),
 	AllowNullable(FetchedProduct.ProductVideo::videoCoverId),
 	AllowNullable(FetchedProduct.ProductVideo::image160pxUrl),
 	AllowNullable(FetchedProduct.ProductVideo::image400pxUrl),


### PR DESCRIPTION
In Ecwid 116234, in order to use alt property in category, the alt needs to be added in the FetchedCategory class. Further more, since the product contains the same alt property for image and later variation, create a new FetchedAlt class and related converting logic for it to be reused.