### PR TITLE
Update prometheus lib to 1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
 	java
 	signing
-	kotlin("jvm") version "1.9.21"
+	kotlin("jvm") version "1.9.23"
 	id("com.adarshr.test-logger") version "3.2.0"
 	id("nebula.release") version "17.1.0"
 	id("maven-publish")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
 	api("com.google.code.gson:gson:2.10")
 	api("org.apache.httpcomponents:httpclient:4.5.13")
-	api("io.prometheus:simpleclient:0.16.0")
+	api("io.prometheus:prometheus-metrics-core:1.1.0")
 
 	testImplementation(kotlin("test"))
 	testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/subscriptions/request/SubscriptionsSearchRequest.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/subscriptions/request/SubscriptionsSearchRequest.kt
@@ -65,8 +65,8 @@ data class SubscriptionsSearchRequest(
 			orderTotal?.let { put("orderTotal", it.toString()) }
 			orderCreatedFrom?.let { put("orderCreatedFrom", TimeUnit.MILLISECONDS.toSeconds(it.time).toString()) }
 			orderCreatedTo?.let { put("orderCreatedTo", TimeUnit.MILLISECONDS.toSeconds(it.time).toString()) }
-			offset?.let { put("offset", it.toString()) }
-			limit?.let { put("limit", it.toString()) }
+			put("offset", offset.toString())
+			put("limit", limit.toString())
 			put("sortBy", sortBy.name)
 			lang?.let { put("lang", it) }
 		}.toMap()

--- a/src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestRetrySleepMetric.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestRetrySleepMetric.kt
@@ -1,13 +1,11 @@
 package com.ecwid.apiclient.v3.metric
 
-import io.prometheus.client.Counter
+import io.prometheus.metrics.core.metrics.Counter
 
 object RequestRetrySleepMetric {
-	private val metric: Counter = Counter
-		.build(
-			"ecwid_api_client_retry_sleep_seconds",
-			"Ecwid API client sleep during retries as result of rate limits (429 http)",
-		)
+	private val metric: Counter = Counter.builder()
+		.name("ecwid_api_client_retry_sleep_seconds_total")
+		.help("Ecwid API client sleep during retries as result of rate limits (429 http)")
 		.register()
 
 	fun inc() {

--- a/src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestSizeMetric.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestSizeMetric.kt
@@ -5,7 +5,8 @@ import com.ecwid.apiclient.v3.httptransport.HttpRequest
 import com.ecwid.apiclient.v3.httptransport.HttpResponse
 import com.ecwid.apiclient.v3.httptransport.TransportHttpBody
 import com.ecwid.apiclient.v3.impl.RequestInfo
-import io.prometheus.client.Histogram
+import io.prometheus.metrics.core.metrics.Histogram
+import io.prometheus.metrics.model.snapshots.Unit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -13,9 +14,11 @@ import java.util.logging.Logger
 private val log = Logger.getLogger(RequestSizeMetric::class.qualifiedName)
 
 object RequestSizeMetric {
-	private val metric: Histogram = Histogram
-		.build("ecwid_api_client_request_size_bytes", "Ecwid API client request size of parameters & body in bytes")
-		.buckets(
+	private val metric = Histogram.builder()
+		.name("ecwid_api_client_request_size_bytes")
+		.help("Ecwid API client request size of parameters & body in bytes")
+		.classicOnly()
+		.classicUpperBounds(
 			100.0,
 			500.0,
 			1_000.0,
@@ -32,6 +35,7 @@ object RequestSizeMetric {
 			100_000_000.0,
 		)
 		.labelNames("request_type", "path", "method", "status")
+		.unit(Unit.BYTES)
 		.register()
 
 	fun observeRequest(
@@ -41,7 +45,7 @@ object RequestSizeMetric {
 		httpResponse: HttpResponse,
 	) {
 		metric
-			.labels(
+			.labelValues(
 				apiRequest.javaClass.simpleName,
 				requestInfo.getFirstPathSegment(),
 				requestInfo.method.name,

--- a/src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestTimeMetric.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestTimeMetric.kt
@@ -3,14 +3,17 @@ package com.ecwid.apiclient.v3.metric
 import com.ecwid.apiclient.v3.dto.ApiRequest
 import com.ecwid.apiclient.v3.httptransport.HttpResponse
 import com.ecwid.apiclient.v3.impl.RequestInfo
-import io.prometheus.client.Collector
-import io.prometheus.client.Histogram
+import io.prometheus.metrics.core.metrics.Histogram
+import io.prometheus.metrics.model.snapshots.Unit
 
 object RequestTimeMetric {
-	private val metric: Histogram = Histogram
-		.build("ecwid_api_client_request_latency", "Ecwid API client request latency")
-		.buckets(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 25.0, 50.0, 100.0, 200.0)
+	private val metric = Histogram.builder()
+		.name("ecwid_api_client_request_latency")
+		.help("Ecwid API client request latency")
+		.classicOnly()
+		.classicUpperBounds(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 25.0, 50.0, 100.0, 200.0)
 		.labelNames("request_type", "path", "method", "status")
+		.unit(Unit.SECONDS)
 		.register()
 
 	fun observeRequest(
@@ -20,12 +23,12 @@ object RequestTimeMetric {
 		httpResponse: HttpResponse,
 	) {
 		metric
-			.labels(
+			.labelValues(
 				apiRequest.javaClass.simpleName,
 				requestInfo.getFirstPathSegment(),
 				requestInfo.method.name,
 				extractStatusFromHttpResponse(httpResponse),
 			)
-			.observe(requestTimeMs / Collector.MILLISECONDS_PER_SECOND)
+			.observe(Unit.millisToSeconds(requestTimeMs))
 	}
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/metric/ResponseSizeMetric.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/metric/ResponseSizeMetric.kt
@@ -3,12 +3,15 @@ package com.ecwid.apiclient.v3.metric
 import com.ecwid.apiclient.v3.dto.ApiRequest
 import com.ecwid.apiclient.v3.httptransport.HttpResponse
 import com.ecwid.apiclient.v3.impl.RequestInfo
-import io.prometheus.client.Histogram
+import io.prometheus.metrics.core.metrics.Histogram
+import io.prometheus.metrics.model.snapshots.Unit
 
 object ResponseSizeMetric {
-	private val metric: Histogram = Histogram
-		.build("ecwid_api_client_response_size_bytes", "Ecwid API client response size in bytes")
-		.buckets(
+	private val metric = Histogram.builder()
+		.name("ecwid_api_client_response_size_bytes")
+		.help("Ecwid API client response size in bytes")
+		.classicOnly()
+		.classicUpperBounds(
 			100.0,
 			500.0,
 			1_000.0,
@@ -25,6 +28,7 @@ object ResponseSizeMetric {
 			100_000_000.0,
 		)
 		.labelNames("request_type", "path", "method", "status")
+		.unit(Unit.BYTES)
 		.register()
 
 	fun observeResponse(
@@ -33,7 +37,7 @@ object ResponseSizeMetric {
 		httpResponse: HttpResponse,
 	) {
 		metric
-			.labels(
+			.labelValues(
 				apiRequest.javaClass.simpleName,
 				requestInfo.getFirstPathSegment(),
 				requestInfo.method.name,


### PR DESCRIPTION
This pull request primarily focuses on two areas of the codebase: the `SubscriptionsSearchRequest` data class and the metrics-related files in the `com.ecwid.apiclient.v3.metric` package. The changes in the `SubscriptionsSearchRequest` data class simplify the code by always setting the `offset` and `limit` parameters. The metrics-related files have been updated to use the `io.prometheus.metrics.core.metrics` package instead of the `io.prometheus.client` package, and several methods and parameters have been renamed or added to align with the new package's conventions.

Changes to `SubscriptionsSearchRequest` data class:

* [`src/main/kotlin/com/ecwid/apiclient/v3/dto/subscriptions/request/SubscriptionsSearchRequest.kt`](diffhunk://#diff-76ff2102c9ffea0bbec16b3e40301d8fc9c10c4d8c927f263b95642f7cea13deL68-R69): The `offset` and `limit` parameters are now always set, regardless of whether they have a value or not.

Changes to metrics-related files:

* [`src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestRetrySleepMetric.kt`](diffhunk://#diff-8d52891545726808e9d27295eecb935e5e6fb18109d5dfc4a93c87e6040a6c11L3-R8): The `Counter` import has been changed from `io.prometheus.client.Counter` to `io.prometheus.metrics.core.metrics.Counter`, and the `metric` object has been updated to use the `Counter.builder()` method.
* [`src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestSizeMetric.kt`](diffhunk://#diff-9c97cb01f1feba251d6c022965abd118be3c46116e7b92827dcd323ff0fe4f46L8-R21): The `Histogram` import has been changed from `io.prometheus.client.Histogram` to `io.prometheus.metrics.core.metrics.Histogram`, and the `metric` object has been updated to use the `Histogram.builder()` method. The `labels()` method has been replaced with the `labelValues()` method. [[1]](diffhunk://#diff-9c97cb01f1feba251d6c022965abd118be3c46116e7b92827dcd323ff0fe4f46L8-R21) [[2]](diffhunk://#diff-9c97cb01f1feba251d6c022965abd118be3c46116e7b92827dcd323ff0fe4f46R38) [[3]](diffhunk://#diff-9c97cb01f1feba251d6c022965abd118be3c46116e7b92827dcd323ff0fe4f46L44-R48)
* [`src/main/kotlin/com/ecwid/apiclient/v3/metric/RequestTimeMetric.kt`](diffhunk://#diff-210757cafedb1b6c9d30ff0108f6c051676d4a6266ab867fc52e237a43736d26L6-R16): The `Histogram` import has been changed from `io.prometheus.client.Histogram` to `io.prometheus.metrics.core.metrics.Histogram`, and the `metric` object has been updated to use the `Histogram.builder()` method. The `labels()` method has been replaced with the `labelValues()` method. [[1]](diffhunk://#diff-210757cafedb1b6c9d30ff0108f6c051676d4a6266ab867fc52e237a43736d26L6-R16) [[2]](diffhunk://#diff-210757cafedb1b6c9d30ff0108f6c051676d4a6266ab867fc52e237a43736d26L23-R32)
* [`src/main/kotlin/com/ecwid/apiclient/v3/metric/ResponseSizeMetric.kt`](diffhunk://#diff-1aceb6b843123ec5e016be73fb4cdcb568604c6940247aa91a73694caae6437cL6-R14): The `Histogram` import has been changed from `io.prometheus.client.Histogram` to `io.prometheus.metrics.core.metrics.Histogram`, and the `metric` object has been updated to use the `Histogram.builder()` method. The `labels()` method has been replaced with the `labelValues()` method. [[1]](diffhunk://#diff-1aceb6b843123ec5e016be73fb4cdcb568604c6940247aa91a73694caae6437cL6-R14) [[2]](diffhunk://#diff-1aceb6b843123ec5e016be73fb4cdcb568604c6940247aa91a73694caae6437cR31) [[3]](diffhunk://#diff-1aceb6b843123ec5e016be73fb4cdcb568604c6940247aa91a73694caae6437cL36-R40)