### PR TITLE
ECWID-116277 Implement alt-text support for all image API

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/AsyncPictureData.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/AsyncPictureData.kt
@@ -3,5 +3,11 @@ package com.ecwid.apiclient.v3.dto.common
 data class AsyncPictureData(
 	val url: String = "",
 	val width: Int = 0,
-	val height: Int = 0
+	val height: Int = 0,
+	val alt: PictureAlt? = null
+)
+
+data class PictureAlt (
+	var main: String? = null,
+	var translated: Map<String, String>? = null
 )

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/AsyncPictureData.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/common/AsyncPictureData.kt
@@ -7,7 +7,7 @@ data class AsyncPictureData(
 	val alt: PictureAlt? = null
 )
 
-data class PictureAlt (
-	var main: String? = null,
-	var translated: Map<String, String>? = null
+data class PictureAlt(
+	val main: String? = null,
+	val translated: Map<String, String>? = null
 )


### PR DESCRIPTION
This pr is to add the additional alt property in api client to support public api change

Based on the [ticket](https://track.ecwid.com/youtrack/issue/ECWID-116277/Implement-alt-text-support-for-all-image-API) description, we need the following implementations:

Add `alt` property in `AsyncPictureData` dto.

Ticket: [ECWID-116277](https://track.ecwid.com/youtrack/issue/ECWID-116277)