### PR TITLE
ECWID-147482: Custom URL slugs for catalog pages: Product and categories export/import in CSV: Custom slugs for categories is not filled after import: set up missing 'customSlug' property

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedCategory.kt
@@ -19,5 +19,6 @@ fun FetchedCategory.toUpdated(): UpdatedCategory {
 		seoDescription = seoDescription,
 		seoDescriptionTranslated = seoDescriptionTranslated,
 		alt = alt?.toUpdated(),
+		customSlug = customSlug,
 	)
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/request/UpdatedCategory.kt
@@ -20,7 +20,8 @@ data class UpdatedCategory(
 	val seoTitleTranslated: LocalizedValueMap? = null,
 	val seoDescription: String? = null,
 	val seoDescriptionTranslated: LocalizedValueMap? = null,
-	val alt: UpdatedAlt? = null
+	val alt: UpdatedAlt? = null,
+	val customSlug: String? = null,
 ) : ApiUpdatedDTO {
 
 	override fun getModifyKind() = ModifyKind.ReadWrite(FetchedCategory::class)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/category/result/FetchedCategory.kt
@@ -26,6 +26,7 @@ data class FetchedCategory(
 	val originalImageUrl: String? = null,
 	val originalImage: PictureInfo? = null,
 	val url: String? = null,
+	val customSlug: String? = null,
 	val productCount: Int? = null,
 	val productCountWithoutSubcategories: Int? = null,
 	val enabledProductCount: Int? = null,

--- a/src/test/kotlin/com/ecwid/apiclient/v3/entity/CategoriesTest.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/entity/CategoriesTest.kt
@@ -179,7 +179,7 @@ class CategoriesTest : BaseEntityTest() {
 		// Searching categories with different combinations of baseUrl and cleanUrls parameters
 		assertCategoryUrlMatchesRegex(
 			categorySearchRequest = CategoriesSearchRequest(),
-			urlPattern = "https://.*.company.site.*/Category-.*-c.*"
+			urlPattern = "https://.*.company.site.*/products#!/Category-.*c.*"
 		)
 		assertCategoryUrlMatchesRegex(
 			categorySearchRequest = CategoriesSearchRequest(
@@ -601,7 +601,8 @@ private fun generateTestCategory(
 		seoDescriptionTranslated = LocalizedValueMap(
 			"ru" to "",
 			"en" to ""
-		)
+		),
+		customSlug = ""
 	)
 }
 

--- a/src/test/kotlin/com/ecwid/apiclient/v3/entity/ProductsTest.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/entity/ProductsTest.kt
@@ -242,7 +242,7 @@ class ProductsTest : BaseEntityTest() {
 		// Searching products with different combinations of baseUrl and cleanUrls parameters
 		assertProductUrlMatchesRegex(
 			productSearchRequest = ByFilters(keyword = productCreateRequest.newProduct.sku),
-			urlPattern = "https://.*.company.site.*/Product-.*-p.*"
+			urlPattern = "https://.*.company.site.*/products#!/Product-.*p.*"
 		)
 		assertProductUrlMatchesRegex(
 			productSearchRequest = ByFilters(

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedCategoryRules.kt
@@ -26,6 +26,7 @@ val fetchedCategoryNullablePropertyRules: List<NullablePropertyRule<*, *>> = lis
 	AllowNullable(FetchedCategory::seoTitle),
 	AllowNullable(FetchedCategory::seoTitleTranslated),
 	AllowNullable(FetchedCategory::seoDescription),
+	AllowNullable(FetchedCategory::customSlug),
 	AllowNullable(FetchedCategory::seoDescriptionTranslated),
 	AllowNullable(FetchedCategory::alt),
 	AllowNullable(FetchedAlt::main),


### PR DESCRIPTION
Ticket: [ECWID-147482](https://track.ecwid.com/youtrack/issue/ECWID-147482/Custom-URL-slugs-for-catalog-pages-Product-and-categories-export-import-in-CSV-Custom-slugs-for-categories-is-not-filled-after)