### PR TITLE
Update deprecated github actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
             ${{ github.workspace }}/build/reports/detekt/detekt.html
 
       - name: Upload static analysis results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: ${{ github.workspace }}/build/reports/detekt/detekt.sarif

--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -37,7 +37,7 @@ jobs:
           GRGIT_PASS: ${{ secrets.GRGIT_PASS }}
 
       - name: Upload static analysis results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: ${{ github.workspace }}/build/reports/detekt/detekt.sarif


### PR DESCRIPTION
Last PR's Actions failed due to use of retired CodeQL Actions. With this PR I'm updating them 

https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/