### PR TITLE
Upgrade version of actions/upload-artifact v3 -> v4

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Upload artifacts with checks results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: check-results


### PR DESCRIPTION
Док по миграции: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

Изучил док, не нашёл ещё где-то использования `actions/upload-artifact` или `actions/download-artifact`, также в изменённом файле нет повторных тасок, кроме build, поэтому не добавлял `overwrite: true`.
`name` также менял, т.к. таска только одна, перезаписи не будет, как и мержа артефактов, если я ничего не путаю.