### PR TITLE
ECWID-163221 New Order Editor: Tax is automatically reset to a standard rate if a product was deleted from catalog

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedOrder.kt
@@ -175,6 +175,7 @@ fun FetchedOrder.OrderItem.toUpdated(): UpdatedOrder.OrderItem {
 		discounts = discounts?.map(FetchedOrder.OrderItemDiscounts::toUpdated),
 		externalReferenceId = externalReferenceId,
 		isPreorder = isPreorder,
+		taxClassCode =  taxClassCode,
 	)
 }
 

--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedOrder.kt
@@ -175,7 +175,7 @@ fun FetchedOrder.OrderItem.toUpdated(): UpdatedOrder.OrderItem {
 		discounts = discounts?.map(FetchedOrder.OrderItemDiscounts::toUpdated),
 		externalReferenceId = externalReferenceId,
 		isPreorder = isPreorder,
-		taxClassCode =  taxClassCode,
+		taxClassCode = taxClassCode,
 	)
 }
 

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/cart/request/OrderForCalculate.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/cart/request/OrderForCalculate.kt
@@ -104,7 +104,8 @@ data class OrderForCalculate(
 		val taxes: List<OrderItemTax>? = null,
 		val files: List<OrderItemProductFile>? = null,
 		val dimensions: ProductDimensions? = null,
-		val discounts: List<OrderItemDiscounts>? = null
+		val discounts: List<OrderItemDiscounts>? = null,
+		val taxClassCode: String? = null
 	)
 
 	data class OrderItemOption(

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/request/UpdatedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/request/UpdatedOrder.kt
@@ -180,6 +180,7 @@ data class UpdatedOrder(
 		val discounts: List<OrderItemDiscounts>? = null,
 		val externalReferenceId: String? = null,
 		val isPreorder: Boolean? = null,
+		var taxClassCode: String? = null,
 	)
 
 	data class OrderItemSelectedOption(

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/request/UpdatedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/request/UpdatedOrder.kt
@@ -180,7 +180,7 @@ data class UpdatedOrder(
 		val discounts: List<OrderItemDiscounts>? = null,
 		val externalReferenceId: String? = null,
 		val isPreorder: Boolean? = null,
-		var taxClassCode: String? = null,
+		val taxClassCode: String? = null,
 	)
 
 	data class OrderItemSelectedOption(

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/result/FetchedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/result/FetchedOrder.kt
@@ -217,7 +217,8 @@ data class FetchedOrder(
 		val discounts: List<OrderItemDiscounts>? = null,
 		val externalReferenceId: String? = null,
 		val isPreorder: Boolean? = null,
-		val attributes: List<OrderItemAttributeValue>? = null
+		val attributes: List<OrderItemAttributeValue>? = null,
+		val taxClassCode: String? = null
 	)
 
 	data class RecurringChargeSettings(

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedOrderRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedOrderRules.kt
@@ -99,6 +99,7 @@ val fetchedOrderNullablePropertyRules: List<NullablePropertyRule<*, *>> = listOf
 	IgnoreNullable(FetchedOrder.OrderItem::externalReferenceId),
 	AllowNullable(FetchedOrder.OrderItem::isPreorder),
 	AllowNullable(FetchedOrder.OrderItem::attributes),
+	IgnoreNullable(FetchedOrder.OrderItem::taxClassCode),
 	IgnoreNullable(FetchedOrder.OrderItemDiscounts::discountInfo),
 	IgnoreNullable(FetchedOrder.OrderItemDiscounts::total),
 	AllowNullable(FetchedOrder.OrderItemOptionFile::id),

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedOrderRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/FetchedOrderRules.kt
@@ -99,7 +99,7 @@ val fetchedOrderNullablePropertyRules: List<NullablePropertyRule<*, *>> = listOf
 	IgnoreNullable(FetchedOrder.OrderItem::externalReferenceId),
 	AllowNullable(FetchedOrder.OrderItem::isPreorder),
 	AllowNullable(FetchedOrder.OrderItem::attributes),
-	IgnoreNullable(FetchedOrder.OrderItem::taxClassCode),
+	AllowNullable(FetchedOrder.OrderItem::taxClassCode),
 	IgnoreNullable(FetchedOrder.OrderItemDiscounts::discountInfo),
 	IgnoreNullable(FetchedOrder.OrderItemDiscounts::total),
 	AllowNullable(FetchedOrder.OrderItemOptionFile::id),

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/OrderForCalculateRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/OrderForCalculateRules.kt
@@ -91,6 +91,7 @@ val orderForCalculateNullablePropertyRules: List<NullablePropertyRule<*, *>> = l
 	IgnoreNullable(OrderForCalculate.OrderItem::taxes),
 	IgnoreNullable(OrderForCalculate.OrderItem::trackQuantity),
 	IgnoreNullable(OrderForCalculate.OrderItem::weight),
+	AllowNullable(OrderForCalculate.OrderItem::taxClassCode),
 	IgnoreNullable(OrderForCalculate.OrderItemDiscountInfo::base),
 	IgnoreNullable(OrderForCalculate.OrderItemDiscountInfo::orderTotal),
 	IgnoreNullable(OrderForCalculate.OrderItemDiscountInfo::type),


### PR DESCRIPTION
Tiket: [ECWID-163221 New Order Editor: Tax is automatically reset to a standard rate if a product was deleted from catalog](https://track.ecwid.com/youtrack/issue/ECWID-163221/New-Order-Editor-Tax-is-automatically-reset-to-a-standard-rate-if-a-product-was-deleted-from-catalog)