### PR TITLE
Add images/main-colors endpoint

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/ApiClient.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/ApiClient.kt
@@ -24,6 +24,8 @@ import com.ecwid.apiclient.v3.dto.customer.request.*
 import com.ecwid.apiclient.v3.dto.customer.result.*
 import com.ecwid.apiclient.v3.dto.customergroup.request.*
 import com.ecwid.apiclient.v3.dto.customergroup.result.*
+import com.ecwid.apiclient.v3.dto.images.request.ImagesMainColorsRequest
+import com.ecwid.apiclient.v3.dto.images.result.FetchedImagesMainColorsResult
 import com.ecwid.apiclient.v3.dto.instantsite.redirects.request.*
 import com.ecwid.apiclient.v3.dto.instantsite.redirects.result.*
 import com.ecwid.apiclient.v3.dto.productreview.request.*
@@ -77,6 +79,7 @@ open class ApiClient private constructor(
 	productReviewsApiClient: ProductReviewsApiClientImpl,
 	storeExtrafieldsApiClient: StoreExtrafieldsApiClientImpl,
 	swatchesApiClient: SwatchesApiClientImpl,
+	imagesApiClient: ImagesApiClientImpl,
 ) :
 	StoreProfileApiClient by storeProfileApiClient,
 	BrandsApiClient by brandsApiClient,
@@ -100,6 +103,7 @@ open class ApiClient private constructor(
 	ProductReviewsApiClient by productReviewsApiClient,
 	StoreExtrafieldsApiClient by storeExtrafieldsApiClient,
 	SwatchesApiClient by swatchesApiClient,
+	ImagesApiClient by imagesApiClient,
 	Closeable {
 
 	constructor(apiClientHelper: ApiClientHelper) : this(
@@ -126,6 +130,7 @@ open class ApiClient private constructor(
 		productReviewsApiClient = ProductReviewsApiClientImpl(apiClientHelper),
 		storeExtrafieldsApiClient = StoreExtrafieldsApiClientImpl(apiClientHelper),
 		swatchesApiClient = SwatchesApiClientImpl(apiClientHelper),
+		imagesApiClient = ImagesApiClientImpl(apiClientHelper),
 	)
 
 	override fun close() {
@@ -331,4 +336,8 @@ interface ProductReviewsApiClient {
 // Swatches
 interface SwatchesApiClient {
 	fun getRecentSwatchColors(request: RecentSwatchColorsGetRequest): FetchedSwatchColorsResult
+}
+
+interface ImagesApiClient {
+	fun getImagesMainColors(request: ImagesMainColorsRequest): FetchedImagesMainColorsResult
 }

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/request/ImagesMainColorsRequest.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/request/ImagesMainColorsRequest.kt
@@ -1,6 +1,7 @@
 package com.ecwid.apiclient.v3.dto.images.request
 
 import com.ecwid.apiclient.v3.dto.ApiRequest
+import com.ecwid.apiclient.v3.dto.common.ApiRequestDTO
 import com.ecwid.apiclient.v3.httptransport.HttpBody
 import com.ecwid.apiclient.v3.impl.RequestInfo
 
@@ -23,4 +24,4 @@ data class ImagesMainColorsRequest(
 data class ImagesMainColorsRequestBody(
 	val imageUrls: List<String> = emptyList(),
 	val colorsCount: Int = 5,
-)
+) : ApiRequestDTO

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/request/ImagesMainColorsRequest.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/request/ImagesMainColorsRequest.kt
@@ -1,0 +1,26 @@
+package com.ecwid.apiclient.v3.dto.images.request
+
+import com.ecwid.apiclient.v3.dto.ApiRequest
+import com.ecwid.apiclient.v3.httptransport.HttpBody
+import com.ecwid.apiclient.v3.impl.RequestInfo
+
+data class ImagesMainColorsRequest(
+	val imagesMainColorsRequest: ImagesMainColorsRequestBody = ImagesMainColorsRequestBody()
+) : ApiRequest {
+	override fun toRequestInfo(): RequestInfo {
+		return RequestInfo.createPostRequest(
+			pathSegments = listOf(
+				"images",
+				"main-colors",
+			),
+			httpBody = HttpBody.JsonBody(
+				obj = imagesMainColorsRequest,
+			)
+		)
+	}
+}
+
+data class ImagesMainColorsRequestBody(
+	val imageUrls: List<String> = emptyList(),
+	val colorsCount: Int = 5,
+)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/result/FetchedImagesMainColorsResult.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/result/FetchedImagesMainColorsResult.kt
@@ -1,0 +1,12 @@
+package com.ecwid.apiclient.v3.dto.images.result
+
+import com.ecwid.apiclient.v3.dto.common.ApiResultDTO
+
+data class FetchedImagesMainColorsResult(
+	val result: Map<String, FetchedImageMainColors>,
+) : ApiResultDTO
+
+
+data class FetchedImageMainColors(
+	val colors: List<String>,
+)

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/result/FetchedImagesMainColorsResult.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/images/result/FetchedImagesMainColorsResult.kt
@@ -3,10 +3,10 @@ package com.ecwid.apiclient.v3.dto.images.result
 import com.ecwid.apiclient.v3.dto.common.ApiResultDTO
 
 data class FetchedImagesMainColorsResult(
-	val result: Map<String, FetchedImageMainColors>,
+	val result: Map<String, FetchedImageMainColors> = emptyMap(),
 ) : ApiResultDTO
 
 
 data class FetchedImageMainColors(
-	val colors: List<String>,
-)
+	val colors: List<String> = emptyList(),
+) : ApiResultDTO

--- a/src/main/kotlin/com/ecwid/apiclient/v3/impl/ImagesApiClientImpl.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/impl/ImagesApiClientImpl.kt
@@ -1,0 +1,14 @@
+package com.ecwid.apiclient.v3.impl
+
+import com.ecwid.apiclient.v3.ApiClientHelper
+import com.ecwid.apiclient.v3.ImagesApiClient
+import com.ecwid.apiclient.v3.dto.images.request.ImagesMainColorsRequest
+import com.ecwid.apiclient.v3.dto.images.result.FetchedImagesMainColorsResult
+
+class ImagesApiClientImpl(
+	private val apiClientHelper: ApiClientHelper,
+) : ImagesApiClient {
+	override fun getImagesMainColors(request: ImagesMainColorsRequest): FetchedImagesMainColorsResult {
+		return apiClientHelper.makeObjectResultRequest<FetchedImagesMainColorsResult>(request)
+	}
+}


### PR DESCRIPTION
For the ticket: [ECWID-165825](https://track.ecwid.com/youtrack/issue/ECWID-165825) Add new endpoint to products service to be able to determine main colors of an image