### PR TITLE
ECOM-7571 Add sourceTaxRateType field to items taxes info

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/converter/FetchedOrder.kt
@@ -213,6 +213,7 @@ fun FetchedOrder.OrderItemTax.toUpdated(): UpdatedOrder.OrderItemTax {
 		taxOnHandlingFee = taxOnHandlingFee,
 		includeInPrice = includeInPrice,
 		taxType = taxType,
+		sourceTaxRateType = sourceTaxRateType,
 	)
 }
 

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/cart/result/CalculateOrderDetailsResult.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/cart/result/CalculateOrderDetailsResult.kt
@@ -192,6 +192,7 @@ data class CalculateOrderDetailsResult(
 		val taxOnDiscountedSubtotal: Double? = null,
 		val taxOnShipping: Double? = null,
 		val taxOnHandlingFee: Double? = null,
+		val sourceTaxRateType: TaxRateType? = null,
 	) : BaseOrderTax
 
 	data class OrderItemProductFile(

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/enums/TaxRateType.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/enums/TaxRateType.kt
@@ -1,0 +1,8 @@
+package com.ecwid.apiclient.v3.dto.order.enums
+
+enum class TaxRateType {
+	AUTO,
+	MANUAL,
+	CUSTOM,
+	LEGACY
+}

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/request/UpdatedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/request/UpdatedOrder.kt
@@ -279,6 +279,7 @@ data class UpdatedOrder(
 		val taxOnShipping: Double? = null,
 		val taxOnHandlingFee: Double? = null,
 		val includeInPrice: Boolean? = null,
+		val sourceTaxRateType: TaxRateType? = null,
 		val taxType: OrderItemTaxType? = null,
 	) : BaseOrderTax
 

--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/result/FetchedOrder.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/order/result/FetchedOrder.kt
@@ -268,16 +268,9 @@ data class FetchedOrder(
 		val taxOnHandlingFee: Double? = null,
 		override val includeInPrice: Boolean? = null,
 		val sourceTaxRateId: Int? = null,
-		val sourceTaxRateType: RateType? = null,
+		val sourceTaxRateType: TaxRateType? = null,
 		val taxType: OrderItemTaxType? = null,
-	) : ExtendedOrderTax {
-		enum class RateType {
-			AUTO,
-			MANUAL,
-			CUSTOM,
-			LEGACY
-		}
-	}
+	) : ExtendedOrderTax
 
 
 	data class HandlingFeeTax(

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/CalculateOrderDetailsResultRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/nullablepropertyrules/CalculateOrderDetailsResultRules.kt
@@ -98,6 +98,7 @@ val calculateOrderDetailsResultNullablePropertyRules: List<NullablePropertyRule<
 	IgnoreNullable(CalculateOrderDetailsResult.OrderItemTax::taxOnDiscountedSubtotal),
 	IgnoreNullable(CalculateOrderDetailsResult.OrderItemTax::taxOnShipping),
 	AllowNullable(CalculateOrderDetailsResult.OrderItemTax::taxOnHandlingFee),
+	AllowNullable(CalculateOrderDetailsResult.OrderItemTax::sourceTaxRateType),
 	IgnoreNullable(CalculateOrderDetailsResult.OrderItemTax::total),
 	IgnoreNullable(CalculateOrderDetailsResult.OrderItemTax::value),
 	IgnoreNullable(CalculateOrderDetailsResult.PersonInfo::city),


### PR DESCRIPTION
Required to set it correctly while calculating and creating order via API if value should differ from default LEGACY