### PR TITLE
ECOM-16792 - add ancestor ids to CategoryInfo

### DIFF
--- a/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
+++ b/src/main/kotlin/com/ecwid/apiclient/v3/dto/product/result/FetchedProduct.kt
@@ -196,6 +196,7 @@ data class FetchedProduct(
 		val enabled: Boolean = true,
 		val name: String = "",
 		val nameTranslated: String = "",
+		val ancestorIds: List<Long>? = null,
 	)
 
 	data class TaxInfo(

--- a/src/test/kotlin/com/ecwid/apiclient/v3/jsontransformer/gson/GsonTransformerTest.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/jsontransformer/gson/GsonTransformerTest.kt
@@ -3,10 +3,12 @@ package com.ecwid.apiclient.v3.jsontransformer.gson
 import com.ecwid.apiclient.v3.dto.common.NullableUpdatedValue
 import com.ecwid.apiclient.v3.dto.order.request.UpdatedOrder
 import com.ecwid.apiclient.v3.dto.product.request.UpdatedProduct
+import com.ecwid.apiclient.v3.dto.product.result.FetchedProduct
 import com.ecwid.apiclient.v3.impl.ParsedResponseWithExt
 import com.google.gson.JsonParser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNull
 
 internal class GsonTransformerTest {
 
@@ -228,6 +230,23 @@ internal class GsonTransformerTest {
 			),
 			deserializedValue
 		)
+	}
+
+	@Test
+	fun `test deserialization of FetchedProduct CategoryInfo with ancestorIds`() {
+		val json = """{"categories": [{"id": 42, "enabled": true, "name": "Cat", "nameTranslated": "", "ancestorIds": [1, 7]}]}"""
+		val product = transformer.deserialize(json, FetchedProduct::class.java)
+		assertEquals(
+			listOf(FetchedProduct.CategoryInfo(id = 42, enabled = true, name = "Cat", nameTranslated = "", ancestorIds = listOf(1L, 7L))),
+			product.categories
+		)
+	}
+
+	@Test
+	fun `test deserialization of FetchedProduct CategoryInfo without ancestorIds defaults to null`() {
+		val json = """{"categories": [{"id": 42, "enabled": true, "name": "Cat", "nameTranslated": ""}]}"""
+		val product = transformer.deserialize(json, FetchedProduct::class.java)
+		assertNull(product.categories?.first()?.ancestorIds)
 	}
 
 	@Test

--- a/src/test/kotlin/com/ecwid/apiclient/v3/rule/NullablePropertyRules.kt
+++ b/src/test/kotlin/com/ecwid/apiclient/v3/rule/NullablePropertyRules.kt
@@ -13,6 +13,7 @@ import com.ecwid.apiclient.v3.dto.order.result.DeletedOrder
 import com.ecwid.apiclient.v3.dto.payment.PaymentAppRequest
 import com.ecwid.apiclient.v3.dto.product.request.ProductInventoryUpdateRequest
 import com.ecwid.apiclient.v3.dto.product.request.ProductUpdateRequest
+import com.ecwid.apiclient.v3.dto.product.result.FetchedProduct.CategoryInfo
 import com.ecwid.apiclient.v3.dto.product.result.GetProductFiltersResult
 import com.ecwid.apiclient.v3.dto.product.result.ProductInventoryUpdateResult
 import com.ecwid.apiclient.v3.dto.productreview.request.UpdatedProductReviewStatus
@@ -161,6 +162,8 @@ val otherNullablePropertyRules: List<NullablePropertyRule<*, *>> = listOf(
 
 	AllowNullable(CustomerGroupsSearchRequest::keyword),
 	AllowNullable(CustomerGroupsSearchRequest::customerGroupIds),
+
+	AllowNullable(CategoryInfo::ancestorIds)
 )
 
 val nullablePropertyRules: List<NullablePropertyRule<*, *>> = listOf(


### PR DESCRIPTION
Added all ids of parent categories to `FetchedProducts`
Will use them to build related entities object of promotion rule
Test fail is not related to changes